### PR TITLE
Fix LineMessageUtility DI error

### DIFF
--- a/src/NetCoreLineBotSDK/Utility/LineMessageUtility.cs
+++ b/src/NetCoreLineBotSDK/Utility/LineMessageUtility.cs
@@ -29,11 +29,11 @@ namespace NetCoreLineBotSDK.Utility
         private const string LineMessageRichMenuAttachApiBaseUrl = "https://api-data.line.me/v2/bot/richmenu";
         private const string LineMessageLinkTokenUrl = "https://api.line.me/v2/bot/user/{userId}/linkToken";
 
-        public LineMessageUtility(IOptions<LineSetting> lineSetting, IHttpClientFactory httpClient)
+        public LineMessageUtility(IOptions<LineSetting> lineSetting, HttpClient httpClient)
         {
             _accessToken = lineSetting.Value.ChannelAccessToken;
             _accountLinkUrl = lineSetting.Value.AccountLinkUrl;
-            _httpClient = httpClient.CreateClient();
+            _httpClient = httpClient;
         }
 
         public async Task<UserProfile> GetUserProfile(string userId)


### PR DESCRIPTION
#2  漏掉了刪除原有的  L:32 以及 L:36

非常抱歉

因修改時自動格式化異動過大，想說只拿主要修改的地方發PR導致，結果導致遺漏掉應刪除的行數

